### PR TITLE
Added bootstrap scss classes for light & dark mode

### DIFF
--- a/src/components/footer/footer.scss
+++ b/src/components/footer/footer.scss
@@ -4,6 +4,8 @@
  * @format
  */
 
+@use "../../styles/bootstrap.scss" as bootstrap;
+
 .footer {
 	margin-top: 12px;
 	display: flex;
@@ -21,5 +23,5 @@
 }
 
 [data-bs-theme="dark"] i.github-icon {
-	color: #ffffff;
+	color: bootstrap.$white;
 }

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -73,7 +73,7 @@ const Footer = () => {
 				</Button>
 			</div>
 			<button className="github-button" onClick={openGithub}>
-				<i className="bi bi-github github-icon" />
+				<i className="bi bi-github github-icon text-primary" />
 			</button>
 			<Modal show={modalIsOpen} onHide={closeModal}>
 				<Modal.Header closeButton>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -73,7 +73,7 @@ const Footer = () => {
 				</Button>
 			</div>
 			<button className="github-button" onClick={openGithub}>
-				<i className="bi bi-github github-icon text-primary" />
+				<i className="bi bi-github github-icon" />
 			</button>
 			<Modal show={modalIsOpen} onHide={closeModal}>
 				<Modal.Header closeButton>


### PR DESCRIPTION
# What does this PR do?
Fixes #118
Changed Github icon from the default black to blue.

I used the Bootstrap class `text-primary` in the `<i className="bi bi-github github-icon text-primary" />`

<img width="1512" alt="Screenshot 2023-06-09 at 2 35 49 PM" src="https://github.com/mg3-codes/d-d-spell-finder/assets/66241121/33ced0b3-166a-4235-a26d-4023298ed1db">

# Type of Change
- Style Enhancement (non-breaking change which makes icon color consistent with the design system)

# How should this be tested?
- Kindly go to the footer and the github icon can be seen in blue color now.

## Edit: According to the updated issue, I have changed the GitHub Icon color to use Bootstrap SCSS classes to use black in light mode and white in dark mode.

<img width="562" alt="image" src="https://github.com/mg3-codes/d-d-spell-finder/assets/66241121/16f5243a-e3d0-4767-9213-860aeccf03e8">

<img width="535" alt="image" src="https://github.com/mg3-codes/d-d-spell-finder/assets/66241121/21a2dcf6-75df-43ef-b85f-54dff6d65d91">

