### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@
 
 name: Build
 
+permissions:
+    contents: read
+
 on:
     push:
         branches: [main, development]


### PR DESCRIPTION
Potential fix for [https://github.com/mg3-codes/d-d-spell-finder/security/code-scanning/2](https://github.com/mg3-codes/d-d-spell-finder/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the minimal permissions required. Since the workflow only performs read operations on the repository (e.g., checking out code), the `contents: read` permission is sufficient. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
