### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,12 @@
 
 name: Test
 
+permissions:
+    contents: read
+
 on:
     push:
-        branches: ["**", "!master"]
+       branches: ["**", "!master"]
 
 jobs:
     test:


### PR DESCRIPTION
Potential fix for [https://github.com/mg3-codes/d-d-spell-finder/security/code-scanning/1](https://github.com/mg3-codes/d-d-spell-finder/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the least privileges required. Since the workflow primarily checks out the repository and runs Cypress tests, it only needs `contents: read` permission. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
